### PR TITLE
Grid mode fix

### DIFF
--- a/app/assets/javascripts/jquery.slick.js
+++ b/app/assets/javascripts/jquery.slick.js
@@ -617,8 +617,9 @@
 
     _.setSlideClasses(typeof _.currentSlide === 'number' ? _.currentSlide : 0);
 
-    if (_.options.draggable === true)
+    if (_.options.draggable === true) {
       _.$list.addClass('draggable');
+    }
   };
 
   Slick.prototype.buildRows = function() {

--- a/app/assets/javascripts/jquery.slick.js
+++ b/app/assets/javascripts/jquery.slick.js
@@ -1881,21 +1881,19 @@
   };
 
   Slick.prototype.refresh = function( initializing ) {
-
     var _ = this, currentSlide, lastVisibleIndex;
 
     lastVisibleIndex = _.slideCount - _.options.slidesToShow;
 
     // in non-infinite sliders, we don't want to go past the
     // last visible index.
-    if( !_.options.infinite && ( _.currentSlide > lastVisibleIndex )) {
+    if(!_.options.infinite && ( _.currentSlide > lastVisibleIndex)) {
       _.currentSlide = lastVisibleIndex;
     }
 
     // if less slides than to show, go to start.
-    if ( _.slideCount <= _.options.slidesToShow ) {
+    if (_.slideCount <= _.options.slidesToShow) {
       _.currentSlide = 0;
-
     }
 
     currentSlide = _.currentSlide;
@@ -1906,17 +1904,16 @@
 
     _.init();
 
-    if( !initializing ) {
-
+    if(!initializing) {
       _.changeSlide({
         data: {
           message: 'index',
           index: currentSlide
         }
       }, false);
-
     }
 
+    _.$slider.trigger('refresh', [_, initializing]);
   };
 
   Slick.prototype.registerBreakpoints = function() {
@@ -1960,7 +1957,6 @@
   };
 
   Slick.prototype.reinit = function() {
-
     var _ = this;
 
     _.$slides =
@@ -2006,7 +2002,6 @@
     _.autoPlay();
 
     _.$slider.trigger('reInit', [_]);
-
   };
 
   Slick.prototype.resize = function() {


### PR DESCRIPTION
## What's Inside

This PR introduces 2 changes: 

- Makes grid mode (rows > 1) work when a slideClass is passed as part of the slider options (which we currently do):  https://github.com/bespokepost/jquery-slick-rails/pull/3/commits/e5b6789f28fb56ea5daade6701a4acdef1687aad
-  Adds a `refresh` event. This will be consumed by a directive in charge of recompiling slides mainly for sliders that use `infinite` or `grid` mode: https://github.com/bespokepost/jquery-slick-rails/pull/3/commits/004022ef2fd69dafd9567c4ab4765524daf0e7da